### PR TITLE
feat(filter): integrate full filter UI, overlay panels, and other state widgets

### DIFF
--- a/lib/application/providers/campsite_provider.dart
+++ b/lib/application/providers/campsite_provider.dart
@@ -12,8 +12,7 @@ final campsiteApiServiceProvider = Provider<CampsiteApiService>((ref) {
 /// Raw campsite list fetched from the API
 final campsiteListProvider = FutureProvider<List<Campsite>>((ref) async {
   final apiService = ref.watch(campsiteApiServiceProvider);
-  final campsites = await apiService.fetchCampsites();
-  return campsites;
+  return apiService.fetchCampsites();
 });
 
 /// Sorted campsite list (by label)
@@ -21,10 +20,12 @@ final sortedCampsiteListProvider = Provider<List<Campsite>>((ref) {
   final asyncValue = ref.watch(campsiteListProvider);
 
   return asyncValue.maybeWhen(
-    data:
-        (list) => [...list]..sort(
-          (a, b) => a.label.toLowerCase().compareTo(b.label.toLowerCase()),
-        ),
+    data: (list) {
+      list.sort(
+        (a, b) => a.label.toLowerCase().compareTo(b.label.toLowerCase()),
+      );
+      return list;
+    },
     orElse: () => [],
   );
 });

--- a/lib/application/providers/filters/filtered_campsites_provider.dart
+++ b/lib/application/providers/filters/filtered_campsites_provider.dart
@@ -8,12 +8,10 @@ import 'campsite_filter_notifier.dart';
 /// It listens to the [campsiteListProvider] for the full list of campsites
 /// and the [campsiteFilterProvider] for the current filter settings.
 final filteredCampsitesProvider = Provider<List<Campsite>>((ref) {
-  final allCampsites = ref
-      .watch(campsiteListProvider)
-      .maybeWhen(data: (data) => data, orElse: () => <Campsite>[]);
+  final sortedCampsites = ref.watch(sortedCampsiteListProvider);
   final filter = ref.watch(campsiteFilterProvider);
 
-  return allCampsites.where((c) {
+  return sortedCampsites.where((c) {
     // Handle Close to Water true/false
     if (filter.isCloseToWater != null &&
         filter.isCloseToWater != c.isCloseToWater) {

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wander_nest/application/providers/campsite_provider.dart';
+import 'package:wander_nest/application/providers/filters/filtered_campsites_provider.dart';
+import 'package:wander_nest/presentation/widgets/filter_panel/filter_action_icon.dart';
+import 'package:wander_nest/presentation/widgets/filter_panel/filter_overlay_panel.dart';
 import 'package:wander_nest/presentation/widgets/home/responsive_campsite_view.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -9,19 +12,37 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final campsiteListAsync = ref.watch(campsiteListProvider);
+    final isCompact = MediaQuery.of(context).size.width < 600;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Wander Nest')),
+      appBar: AppBar(
+        title: const Text('Wander Nest'),
+        actions: [
+          if (isCompact)
+            /// Compact view: Show filter icon with badge
+            FilterActionIcon(
+              onPressed:
+                  () => showModalBottomSheet(
+                    context: context,
+                    isScrollControlled: true,
+                    builder: (_) => const FilterOverlayPanel(),
+                  ),
+            ),
+        ],
+      ),
       body: campsiteListAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error:
             (err, _) => Center(
               child: Text('Error: ${err.toString()}'),
             ), //TODO: Create Error Widget
-        data: (_) {
-          final sortedCampsites = ref.watch(sortedCampsiteListProvider);
+        data: (allCampsites) {
+          final filteredCampsites = ref.watch(filteredCampsitesProvider);
 
-          return ResponsiveCampsiteView(campsites: sortedCampsites);
+          return ResponsiveCampsiteView(
+            campsites: allCampsites,
+            filteredCampsites: filteredCampsites,
+          );
         },
       ),
     );

--- a/lib/presentation/widgets/filter_panel/active_filter_chips.dart
+++ b/lib/presentation/widgets/filter_panel/active_filter_chips.dart
@@ -22,24 +22,24 @@ class ActiveFilterChips extends ConsumerWidget {
 
     if (filter.isCloseToWater != null) {
       chips.add(
-        _buildFilterChip(
-          context,
-          filter.isCloseToWater == true
-              ? 'Close to Water'
-              : 'Not Close to Water',
-          () => filterNotifier.toggleWaterFilter(null),
+        FilterChip(
+          label:
+              filter.isCloseToWater == true
+                  ? 'Close to Water'
+                  : 'Not Close to Water',
+          onDeleted: () => filterNotifier.toggleWaterFilter(null),
         ),
       );
     }
 
     if (filter.isCampFireAllowed != null) {
       chips.add(
-        _buildFilterChip(
-          context,
-          filter.isCampFireAllowed == true
-              ? 'Campfire Allowed'
-              : 'Campfire Not Allowed',
-          () => filterNotifier.toggleCampfireFilter(null),
+        FilterChip(
+          label:
+              filter.isCampFireAllowed == true
+                  ? 'Campfire Allowed'
+                  : 'Campfire Not Allowed',
+          onDeleted: () => filterNotifier.toggleCampfireFilter(null),
         ),
       );
     }
@@ -47,26 +47,26 @@ class ActiveFilterChips extends ConsumerWidget {
     if (filter.hostLanguages != null && filter.hostLanguages!.isNotEmpty) {
       for (final lang in filter.hostLanguages!) {
         chips.add(
-          _buildFilterChip(context, lang, () {
-            final newList = List<String>.from(filter.hostLanguages!);
-            newList.remove(lang);
-            filterNotifier.updateHostLanguages(
-              newList.isEmpty ? null : newList,
-            );
-          }),
+          FilterChip(
+            label: lang,
+            onDeleted: () {
+              final newList = List<String>.from(filter.hostLanguages!);
+              newList.remove(lang);
+              filterNotifier.updateHostLanguages(
+                newList.isEmpty ? null : newList,
+              );
+            },
+          ),
         );
       }
     }
 
     if (filter.priceRange != null && filter.priceRange != initialPriceRange) {
       chips.add(
-        _buildFilterChip(
-          context,
-          'Price: €${filter.priceRange!.start.round()} - \$${filter.priceRange!.end.round()}',
-          () => filterNotifier.updatePriceRange(
-            initialPriceRange.start,
-            initialPriceRange.end,
-          ),
+        FilterChip(
+          label:
+              'Price: €${filter.priceRange!.start.round()} - \$${filter.priceRange!.end.round()}',
+          onDeleted: () => filterNotifier.updatePriceRange(null, null),
         ),
       );
     }
@@ -88,12 +88,15 @@ class ActiveFilterChips extends ConsumerWidget {
       ),
     );
   }
+}
 
-  Widget _buildFilterChip(
-    BuildContext context,
-    String label,
-    VoidCallback onDeleted,
-  ) {
+class FilterChip extends StatelessWidget {
+  const FilterChip({super.key, required this.label, required this.onDeleted});
+  final String label;
+  final VoidCallback onDeleted;
+
+  @override
+  Widget build(BuildContext context) {
     return Chip(
       label: Text(label),
       onDeleted: onDeleted,

--- a/lib/presentation/widgets/filter_panel/filter_action_icon.dart
+++ b/lib/presentation/widgets/filter_panel/filter_action_icon.dart
@@ -26,9 +26,9 @@ class FilterActionIcon extends ConsumerWidget {
               backgroundColor: Theme.of(context).colorScheme.secondary,
               child: Text(
                 '$appliedCount',
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 12,
-                  color: Colors.white,
+                  color: Theme.of(context).colorScheme.onSecondary,
                   fontWeight: FontWeight.bold,
                 ),
               ),

--- a/lib/presentation/widgets/filter_panel/filter_overlay_panel.dart
+++ b/lib/presentation/widgets/filter_panel/filter_overlay_panel.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/application/providers/campsite_provider.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_model.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_notifier.dart';
+import 'package:wander_nest/core/constants/app_icons.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/presentation/widgets/filters/dropdown_filter_option.dart';
+import 'package:wander_nest/presentation/widgets/filters/language_filter_selector.dart';
+import 'package:wander_nest/presentation/widgets/filters/price_range_slider.dart';
+
+class FilterOverlayPanel extends ConsumerStatefulWidget {
+  const FilterOverlayPanel({super.key});
+
+  @override
+  ConsumerState<FilterOverlayPanel> createState() =>
+      _CampsiteFilterSheetMobileState();
+}
+
+class _CampsiteFilterSheetMobileState
+    extends ConsumerState<FilterOverlayPanel> {
+  late CampsiteFilter _localFilter;
+  late RangeValues _localPriceRange;
+
+  @override
+  void initState() {
+    super.initState();
+    final globalFilter = ref.read(campsiteFilterProvider);
+    final globalPriceRange = ref.read(priceRangeProvider);
+
+    _localFilter = globalFilter;
+    _localPriceRange = _localFilter.priceRange ?? globalPriceRange;
+  }
+
+  void _applyFilters() {
+    ref.read(campsiteFilterProvider.notifier).setFilter(_localFilter);
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final priceRange = ref.watch(priceRangeProvider);
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSizes.padding),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // Header
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Filters', style: Theme.of(context).textTheme.titleMedium),
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _localFilter = const CampsiteFilter();
+                      _localPriceRange = priceRange;
+                    });
+                  },
+                  child: const Text('Clear All'),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+
+            const SizedBox(height: AppSizes.space),
+
+            // Water toggle: Yes / No / Any
+            DropdownFilterOption(
+              title: 'Close to Water',
+              icon: AppIcons.water,
+              value: _localFilter.isCloseToWater,
+              onChanged: (value) {
+                setState(() {
+                  _localFilter = _localFilter.copyWith(isCloseToWater: value);
+                });
+              },
+            ),
+
+            // Campfire toggle
+            DropdownFilterOption(
+              title: 'Campfire Allowed',
+              icon: AppIcons.campfire,
+              value: _localFilter.isCampFireAllowed,
+              onChanged: (value) {
+                setState(() {
+                  _localFilter = _localFilter.copyWith(
+                    isCampFireAllowed: value,
+                  );
+                });
+              },
+            ),
+
+            // Host languages
+            LanguageFilterSelector(
+              selectedLanguages: _localFilter.hostLanguages ?? [],
+              onSelectionChanged: (selected) {
+                setState(() {
+                  _localFilter = _localFilter.copyWith(
+                    hostLanguages: selected.isEmpty ? null : selected,
+                  );
+                });
+              },
+            ),
+
+            const SizedBox(height: AppSizes.space),
+
+            // Price slider
+            PriceRangeSlider(
+              currentRange: _localPriceRange,
+              min: priceRange.start,
+              max: priceRange.end,
+              onChanged: (range) {
+                setState(() {
+                  _localPriceRange = range;
+                  _localFilter = _localFilter.copyWith(priceRange: range);
+                });
+              },
+            ),
+
+            const SizedBox(height: AppSizes.space),
+
+            ElevatedButton(
+              onPressed: _applyFilters,
+              child: const Text('Apply Filters'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/filter_panel/filter_sidebar_panel.dart
+++ b/lib/presentation/widgets/filter_panel/filter_sidebar_panel.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/application/providers/campsite_provider.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_notifier.dart';
+import 'package:wander_nest/core/constants/app_icons.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/presentation/widgets/filters/dropdown_filter_option.dart';
+import 'package:wander_nest/presentation/widgets/filters/language_filter_selector.dart';
+import 'package:wander_nest/presentation/widgets/filters/price_range_slider.dart';
+
+class FilterSidebarPanel extends ConsumerWidget {
+  const FilterSidebarPanel({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final priceRange = ref.watch(priceRangeProvider);
+    final filter = ref.watch(campsiteFilterProvider);
+    final filterNotifier = ref.read(campsiteFilterProvider.notifier);
+
+    final currentRange = filter.priceRange ?? priceRange;
+
+    return Drawer(
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizes.paddingSM,
+            vertical: AppSizes.padding,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Filters', style: Theme.of(context).textTheme.headlineSmall),
+
+              // Water tri-state toggle
+              DropdownFilterOption(
+                title: 'Close to Water',
+                icon: AppIcons.water,
+                value: filter.isCloseToWater,
+                onChanged: filterNotifier.toggleWaterFilter,
+              ),
+
+              // Campfire tri-state toggle
+              DropdownFilterOption(
+                title: 'Campfire Allowed',
+                icon: AppIcons.campfire,
+                value: filter.isCampFireAllowed,
+                onChanged: filterNotifier.toggleCampfireFilter,
+              ),
+
+              // Host languages multi-select
+              LanguageFilterSelector(
+                selectedLanguages: filter.hostLanguages ?? [],
+                onSelectionChanged: (selected) {
+                  filterNotifier.updateHostLanguages(
+                    selected.isEmpty ? null : selected,
+                  );
+                },
+              ),
+
+              PriceRangeSlider(
+                currentRange: currentRange,
+                min: priceRange.start,
+                max: priceRange.end,
+                onChanged:
+                    (range) =>
+                        filterNotifier.updatePriceRange(range.start, range.end),
+              ),
+
+              const SizedBox(height: AppSizes.spaceLG),
+              Center(
+                child: ElevatedButton(
+                  onPressed: filterNotifier.resetFilters,
+                  child: const Text(
+                    'Clear Filters',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/filters/language_filter_selector.dart
+++ b/lib/presentation/widgets/filters/language_filter_selector.dart
@@ -27,6 +27,18 @@ class _LanguageFilterSelectorState extends State<LanguageFilterSelector> {
   }
 
   @override
+  void didUpdateWidget(covariant LanguageFilterSelector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.selectedLanguages != widget.selectedLanguages) {
+      setState(() {
+        _selectedLanguages = List.from(
+          widget.selectedLanguages.map((e) => e.toUpperCase()),
+        );
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return ExpansionTile(
       title: const Text('Host Languages'),

--- a/lib/presentation/widgets/home/home_compact_layout.dart
+++ b/lib/presentation/widgets/home/home_compact_layout.dart
@@ -1,30 +1,58 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_notifier.dart';
 import 'package:wander_nest/core/constants/app_sizes.dart';
 import 'package:wander_nest/data/models/campsite.dart';
+import 'package:wander_nest/presentation/widgets/filter_panel/active_filter_chips.dart';
 import 'package:wander_nest/presentation/widgets/home/campsite_card.dart';
+import 'package:wander_nest/presentation/widgets/home/home_empty_campsite.dart';
+import 'package:wander_nest/presentation/widgets/home/result_summary_banner.dart';
 
 class HomeCompactLayout extends ConsumerWidget {
-  const HomeCompactLayout({super.key, required this.campsites});
+  const HomeCompactLayout({
+    super.key,
+    required this.campsites,
+    required this.filteredCampsites,
+  });
 
   final List<Campsite> campsites;
+  final List<Campsite> filteredCampsites;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    Widget content = const Center(child: Text('No Campsites Available'));
+    final filter = ref.watch(campsiteFilterProvider);
 
-    if (campsites.isNotEmpty) {
+    Widget content = const NoCampsiteFound();
+
+    if (filteredCampsites.isNotEmpty) {
       content = ListView.separated(
         padding: const EdgeInsets.all(AppSizes.padding),
-        itemCount: campsites.length,
+        itemCount: filteredCampsites.length,
         separatorBuilder: (_, __) => const SizedBox(height: AppSizes.space),
         itemBuilder: (context, index) {
-          final campsite = campsites[index];
+          final campsite = filteredCampsites[index];
           return CampsiteCard(campsite: campsite);
         },
       );
     }
 
-    return content;
+    return Column(
+      children: [
+        if (!filter.isEmpty)
+          const Padding(
+            padding: EdgeInsets.only(top: AppSizes.padding),
+            child: ActiveFilterChips(),
+          ),
+        if (filteredCampsites.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: AppSizes.padding),
+            child: ResultSummaryBanner(
+              totalCount: campsites.length,
+              filteredCount: filteredCampsites.length,
+            ),
+          ),
+        Expanded(child: content),
+      ],
+    );
   }
 }

--- a/lib/presentation/widgets/home/home_empty_campsite.dart
+++ b/lib/presentation/widgets/home/home_empty_campsite.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/shared/extensions/color_extensions.dart';
+
+class NoCampsiteFound extends StatelessWidget {
+  const NoCampsiteFound({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Center(
+          child: Padding(
+            padding: const EdgeInsets.all(AppSizes.paddingLG),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.center,
+
+              children: [
+                Icon(
+                  Icons.search_off,
+                  size: AppSizes.iconXL,
+                  color: Theme.of(context).colorScheme.onSurface.alphaF(0.6),
+                ),
+                const SizedBox(height: AppSizes.paddingSM),
+                Text(
+                  'No Capsite Found',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface.alphaF(0.8),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Text(
+                  'Try adjusting your filters or search criteria.',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface.alphaF(0.8),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/widgets/home/home_wide_layout.dart
+++ b/lib/presentation/widgets/home/home_wide_layout.dart
@@ -1,36 +1,77 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wander_nest/core/constants/app_sizes.dart';
 import 'package:wander_nest/data/models/campsite.dart';
+import 'package:wander_nest/presentation/widgets/filter_panel/filter_sidebar_panel.dart';
 import 'package:wander_nest/presentation/widgets/home/campsite_card.dart';
+import 'package:wander_nest/presentation/widgets/home/home_empty_campsite.dart';
+import 'package:wander_nest/presentation/widgets/home/result_summary_banner.dart';
 
-class HomeWideLayout extends StatelessWidget {
+class HomeWideLayout extends ConsumerWidget {
   const HomeWideLayout({
     super.key,
-    required this.campsites,
     required this.width,
+    required this.campsites,
+    required this.filteredCampsites,
   });
 
   final List<Campsite> campsites;
+  final List<Campsite> filteredCampsites;
   final double width;
 
   @override
-  Widget build(BuildContext context) {
-    final crossAxisCount = width ~/ 300;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filterPanelWidth = 300;
+    final availableWidth = width - filterPanelWidth;
+    final crossAxisCount = availableWidth ~/ 300;
 
     return Padding(
       padding: const EdgeInsets.all(AppSizes.padding),
-      child: GridView.builder(
-        itemCount: campsites.length,
-        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: crossAxisCount,
-          mainAxisSpacing: AppSizes.space,
-          crossAxisSpacing: AppSizes.space,
-          childAspectRatio: 0.95,
-        ),
-        itemBuilder: (context, index) {
-          final campsite = campsites[index];
-          return CampsiteCard(campsite: campsite);
-        },
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Left-side filter panel
+          SizedBox(
+            width: filterPanelWidth.toDouble(),
+            child: const FilterSidebarPanel(),
+          ),
+
+          const SizedBox(width: AppSizes.space),
+
+          // Right-side filtered list of campsites
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: AppSizes.space),
+                if (filteredCampsites.isNotEmpty)
+                  ResultSummaryBanner(
+                    totalCount: campsites.length,
+                    filteredCount: filteredCampsites.length,
+                  ),
+
+                if (filteredCampsites.isEmpty)
+                  const Expanded(child: NoCampsiteFound())
+                else
+                  Expanded(
+                    child: GridView.builder(
+                      itemCount: filteredCampsites.length,
+                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: crossAxisCount,
+                        mainAxisSpacing: AppSizes.space,
+                        crossAxisSpacing: AppSizes.space,
+                        childAspectRatio: 0.75,
+                      ),
+                      itemBuilder: (context, index) {
+                        final campsite = filteredCampsites[index];
+                        return CampsiteCard(campsite: campsite);
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/widgets/home/responsive_campsite_view.dart
+++ b/lib/presentation/widgets/home/responsive_campsite_view.dart
@@ -4,9 +4,14 @@ import 'package:wander_nest/presentation/widgets/home/home_compact_layout.dart';
 import 'package:wander_nest/presentation/widgets/home/home_wide_layout.dart';
 
 class ResponsiveCampsiteView extends StatelessWidget {
-  const ResponsiveCampsiteView({super.key, required this.campsites});
+  const ResponsiveCampsiteView({
+    super.key,
+    required this.campsites,
+    required this.filteredCampsites,
+  });
 
   final List<Campsite> campsites;
+  final List<Campsite> filteredCampsites;
 
   @override
   Widget build(BuildContext context) {
@@ -15,8 +20,15 @@ class ResponsiveCampsiteView extends StatelessWidget {
         final isCompact = constraints.maxWidth < 600;
 
         return isCompact
-            ? HomeCompactLayout(campsites: campsites)
-            : HomeWideLayout(campsites: campsites, width: constraints.maxWidth);
+            ? HomeCompactLayout(
+              campsites: campsites,
+              filteredCampsites: filteredCampsites,
+            )
+            : HomeWideLayout(
+              campsites: campsites,
+              filteredCampsites: filteredCampsites,
+              width: constraints.maxWidth,
+            );
       },
     );
   }

--- a/lib/presentation/widgets/home/result_summary_banner.dart
+++ b/lib/presentation/widgets/home/result_summary_banner.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/shared/extensions/color_extensions.dart';
+
+class ResultSummaryBanner extends StatelessWidget {
+  const ResultSummaryBanner({
+    super.key,
+    required this.totalCount,
+    required this.filteredCount,
+    this.showIfUnfiltered = true,
+  });
+
+  final int totalCount;
+  final int filteredCount;
+  final bool showIfUnfiltered;
+
+  bool get isFiltered => filteredCount != totalCount;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isFiltered && !showIfUnfiltered) return const SizedBox.shrink();
+
+    final textTheme = Theme.of(context).textTheme;
+
+    final label =
+        isFiltered
+            ? '$filteredCount of $totalCount campsites match your filters'
+            : '$totalCount campsites available';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSizes.paddingSM),
+      child: Card(
+        color: Theme.of(context).colorScheme.primary.alphaF(0.2),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSizes.radius),
+        ),
+        elevation: 0,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSizes.paddingSM),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                isFiltered ? Icons.filter_alt_outlined : Icons.info_outline,
+                size: AppSizes.icon,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+              const SizedBox(width: AppSizes.spaceSM),
+              Text(label, style: textTheme.bodyMedium),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- Add sidebar filter panel for wide layout and overlay panel for compact layout
- Update `filteredCampsitesProvider` to use the sorted list
- Refactor filter chips and filter option widgets for better clarity and reuse
- Add empty state widget for when no campsites match selected filters
- Add `ResultSummaryBanner` widget that displays the number of campsites