### PR TITLE
feat(map): add clustering, map controller, providers, and navigation flow

### DIFF
--- a/lib/application/providers/map/map_controller_notifier.dart
+++ b/lib/application/providers/map/map_controller_notifier.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:wander_nest/application/providers/map/map_state.dart';
+import 'package:wander_nest/data/models/campsite.dart';
+import 'package:wander_nest/data/models/map_cluster.dart';
+
+// Controls the state of the map including zoom, center, and cluster data
+class MapControllerNotifier extends StateNotifier<MapState> {
+  MapControllerNotifier()
+    : super(const MapState(clusters: [], currentZoom: 10.0));
+
+  static const double _minZoomForClustering = 13.0;
+
+  // Controls the state of the map including zoom, center, and cluster data
+  void updateClusters(List<Campsite> campsites, double zoom) {
+    state = state.copyWith(currentZoom: zoom);
+
+    if (campsites.isEmpty) {
+      state = state.copyWith(clusters: []);
+      return;
+    }
+
+    final center = _calculateCenter(campsites);
+    final clusters = _performDynamicClustering(campsites, zoom);
+
+    state = state.copyWith(
+      clusters: clusters,
+      center: center,
+      isLoading: false,
+      error: null,
+    );
+  }
+
+  void setLoading(bool loading) {
+    state = state.copyWith(isLoading: loading);
+  }
+
+  void setError(String error) {
+    state = state.copyWith(error: error, isLoading: false);
+  }
+
+  // Calculates the geographic center (average lat/lng) of given campsites
+  LatLng _calculateCenter(List<Campsite> campsites) {
+    final totalLat = campsites.fold(0.0, (sum, c) => sum + c.geoLocation.lat);
+    final totalLng = campsites.fold(0.0, (sum, c) => sum + c.geoLocation.long);
+    return LatLng(totalLat / campsites.length, totalLng / campsites.length);
+  }
+
+  // Groups campsites into clusters based on zoom level and spatial proximity
+  List<MapCluster> _performDynamicClustering(
+    List<Campsite> campsites,
+    double zoom,
+  ) {
+    final double gridSize = _calculateGridSize(zoom);
+    final Map<String, List<Campsite>> gridClusters = {};
+
+    for (final campsite in campsites) {
+      final key = _getGridKey(
+        campsite.geoLocation.lat,
+        campsite.geoLocation.long,
+        gridSize,
+      );
+      gridClusters.putIfAbsent(key, () => []).add(campsite);
+    }
+
+    final List<MapCluster> clusters = [];
+
+    // Create clusters or single markers depending on number of campsites and zoom
+    for (final group in gridClusters.values) {
+      if (group.isEmpty) continue;
+
+      // If single campsite and zoomed in enough, show as individual marker
+      if (group.length == 1 && zoom >= _minZoomForClustering) {
+        clusters.add(
+          MapCluster(
+            position: LatLng(
+              group.first.geoLocation.lat,
+              group.first.geoLocation.long,
+            ),
+            campsites: group,
+            isCluster: false,
+          ),
+        );
+      } else {
+        // Otherwise, show as a cluster with center position
+        final center = _calculateCenter(group);
+        clusters.add(
+          MapCluster(
+            position: center,
+            campsites: group,
+            isCluster: group.length > 1,
+          ),
+        );
+      }
+    }
+
+    return clusters;
+  }
+
+  // Determines grid size dynamically based on zoom level to control clustering precision
+  double _calculateGridSize(double zoom) {
+    if (zoom <= 3) return 10.0;
+    if (zoom <= 5) return 1.0;
+    if (zoom <= 7) return 0.5;
+    if (zoom <= 9) return 0.3;
+    if (zoom <= 10) return 0.2;
+    if (zoom <= 13) return 0.1;
+    return 0.1; // Default for higher zoom levels
+  }
+
+  // Calculates a grid key (string) to group campsites into spatial buckets
+  String _getGridKey(double lat, double lng, double gridSize) {
+    final latGrid = (lat / gridSize).floor();
+    final lngGrid = (lng / gridSize).floor();
+    return '$latGrid,$lngGrid';
+  }
+}

--- a/lib/application/providers/map/map_providers.dart
+++ b/lib/application/providers/map/map_providers.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/application/providers/filters/filtered_campsites_provider.dart';
+import 'package:wander_nest/application/providers/map/map_controller_notifier.dart';
+import 'package:wander_nest/application/providers/map/map_state.dart';
+import 'package:wander_nest/data/models/map_cluster.dart';
+
+final mapControllerProvider =
+    StateNotifierProvider<MapControllerNotifier, MapState>(
+      (ref) => MapControllerNotifier(),
+    );
+
+// Watches filtered campsites and triggers cluster generation on zoom change
+final mapClustersProvider = Provider<AsyncValue<List<MapCluster>>>((ref) {
+  final campsites = ref.watch(filteredCampsitesProvider);
+  final mapState = ref.watch(mapControllerProvider);
+
+  if (campsites.isEmpty) {
+    return const AsyncValue.data([]);
+  }
+
+  // Trigger cluster update after build
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    ref
+        .read(mapControllerProvider.notifier)
+        .updateClusters(campsites, mapState.currentZoom);
+  });
+
+  return AsyncValue.data(mapState.clusters);
+});

--- a/lib/application/providers/map/map_state.dart
+++ b/lib/application/providers/map/map_state.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import 'package:latlong2/latlong.dart';
+import 'package:wander_nest/data/models/map_cluster.dart';
+
+/// Represents the current state of the map, including zoom level,
+/// clusters/markers, center position, loading status, and any errors.
+@immutable
+class MapState {
+  const MapState({
+    required this.clusters,
+    required this.currentZoom,
+    this.center,
+    this.isLoading = false,
+    this.error,
+  });
+  final List<MapCluster> clusters;
+  final double currentZoom;
+  final LatLng? center;
+  final bool isLoading;
+  final String? error;
+
+  MapState copyWith({
+    List<MapCluster>? clusters,
+    double? currentZoom,
+    LatLng? center,
+    bool? isLoading,
+    String? error,
+  }) {
+    return MapState(
+      clusters: clusters ?? this.clusters,
+      currentZoom: currentZoom ?? this.currentZoom,
+      center: center ?? this.center,
+      isLoading: isLoading ?? this.isLoading,
+      error: error ?? this.error,
+    );
+  }
+}

--- a/lib/data/models/map_cluster.dart
+++ b/lib/data/models/map_cluster.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:wander_nest/data/models/campsite.dart';
+
+/// Represents either a single campsite marker or a cluster of campsites
+/// on the map, with its position and contained campsites.
+@immutable
+class MapCluster {
+  const MapCluster({
+    required this.position,
+    required this.campsites,
+    required this.isCluster,
+  });
+  final LatLng position;
+  final List<Campsite> campsites;
+  final bool isCluster;
+
+  int get count => campsites.length;
+
+  Campsite get firstCampsite => campsites.first;
+}

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wander_nest/application/providers/campsite_provider.dart';
 import 'package:wander_nest/application/providers/filters/filtered_campsites_provider.dart';
+import 'package:wander_nest/presentation/screens/map_screen.dart';
 import 'package:wander_nest/presentation/widgets/filter_panel/filter_action_icon.dart';
 import 'package:wander_nest/presentation/widgets/filter_panel/filter_overlay_panel.dart';
 import 'package:wander_nest/presentation/widgets/home/app_error_message.dart';
@@ -13,12 +14,14 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final campsiteListAsync = ref.watch(campsiteListProvider);
+    final filteredCampsites = ref.watch(filteredCampsitesProvider);
     final isCompact = MediaQuery.of(context).size.width < 600;
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('Wander Nest'),
         actions: [
+          _buildMapIconButton(context, filteredCampsites.isEmpty),
           if (isCompact)
             /// Compact view: Show filter icon with badge
             FilterActionIcon(
@@ -39,14 +42,33 @@ class HomeScreen extends ConsumerWidget {
               onRetry: () => ref.refresh(campsiteListProvider),
             ),
         data: (allCampsites) {
-          final filteredCampsites = ref.watch(filteredCampsitesProvider);
-
           return ResponsiveCampsiteView(
             campsites: allCampsites,
             filteredCampsites: filteredCampsites,
           );
         },
       ),
+    );
+  }
+
+  Widget _buildMapIconButton(BuildContext context, bool isCampsitesEmpty) {
+    return IconButton(
+      icon: const Icon(Icons.map),
+      onPressed: () {
+        if (isCampsitesEmpty) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('No campsites to display on map'),
+              duration: Duration(seconds: 2),
+            ),
+          );
+          return;
+        }
+        Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const MapScreen()),
+        );
+      },
     );
   }
 }

--- a/lib/presentation/screens/map_screen.dart
+++ b/lib/presentation/screens/map_screen.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:wander_nest/application/providers/filters/filtered_campsites_provider.dart';
+import 'package:wander_nest/application/providers/map/map_providers.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/data/models/map_cluster.dart';
+import 'package:wander_nest/presentation/screens/campsite_detail_screen.dart';
+import 'package:wander_nest/presentation/widgets/maps/campsite_cluster_preview_list.dart';
+import 'package:wander_nest/presentation/widgets/maps/campsite_marker_icon.dart';
+import 'package:wander_nest/presentation/widgets/maps/cluster_count_marker.dart';
+
+class MapScreen extends ConsumerStatefulWidget {
+  const MapScreen({super.key});
+
+  @override
+  ConsumerState<MapScreen> createState() => _MapScreenState();
+}
+
+class _MapScreenState extends ConsumerState<MapScreen> {
+  late final MapController _mapController;
+  bool _hasMovedToInitialCenter = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _mapController = MapController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = ref.watch(mapControllerProvider);
+    final clustersAsync = ref.watch(mapClustersProvider);
+
+    // Use a fallback center if null
+    final center =
+        mapState.center ?? const LatLng(37.7749, -122.4194); // San Francisco
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Campsites Map')),
+      body: clustersAsync.when(
+        data: (clusters) {
+          if (!_hasMovedToInitialCenter && mapState.center != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              _mapController.move(mapState.center!, mapState.currentZoom);
+              _hasMovedToInitialCenter = true;
+            });
+          }
+
+          return FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              initialCenter: center,
+              initialZoom: mapState.currentZoom,
+              maxZoom: 18,
+              minZoom: 3,
+              onPositionChanged: (position, hasGesture) {
+                _onMapPositionChanged(position.zoom);
+              },
+            ),
+            children: [
+              TileLayer(
+                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                userAgentPackageName: 'com.example.wanderNest',
+                maxZoom: 18,
+              ),
+              MarkerLayer(markers: _buildMarkers(clusters)),
+            ],
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error:
+            (error, _) =>
+                Center(child: Text('Error loading campsites: $error')),
+      ),
+    );
+  }
+
+  List<Marker> _buildMarkers(List<MapCluster> clusters) {
+    return clusters.map((cluster) {
+      return Marker(
+        point: cluster.position,
+        width: AppSizes.iconXL,
+        height: AppSizes.iconXL,
+        child: GestureDetector(
+          onTap: () => _onClusterTap(cluster),
+          child:
+              cluster.isCluster
+                  ? ClusterCountMarker(cluster.count)
+                  : const CampsiteMarkerIcon(),
+        ),
+      );
+    }).toList();
+  }
+
+  // Update clusters if zoom level has changed
+  void _onMapPositionChanged(double zoom) {
+    final mapState = ref.read(mapControllerProvider);
+    final campsites = ref.read(filteredCampsitesProvider);
+
+    if ((zoom - mapState.currentZoom).abs() > 0.1) {
+      ref.read(mapControllerProvider.notifier).updateClusters(campsites, zoom);
+    }
+  }
+
+  void _onClusterTap(MapCluster cluster) {
+    if (cluster.isCluster && cluster.count > 1) {
+      // Multiple campsite - Show a modal bottom sheet listing the campsites in the cluster
+      showModalBottomSheet(
+        context: context,
+        builder:
+            (context) =>
+                CampsiteClusterPreviewList(campsites: cluster.campsites),
+      );
+    } else {
+      // Single campsite - navigate to detail or show popup
+      final campsite = cluster.firstCampsite;
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => CampsiteDetailScreen(campsite: campsite),
+        ),
+      );
+    }
+  }
+}

--- a/lib/presentation/widgets/maps/campsite_cluster_preview_list.dart
+++ b/lib/presentation/widgets/maps/campsite_cluster_preview_list.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:wander_nest/core/constants/app_icons.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/core/themes/app_custom_colors.dart';
+import 'package:wander_nest/data/models/campsite.dart';
+import 'package:wander_nest/presentation/screens/campsite_detail_screen.dart';
+import 'package:wander_nest/shared/extensions/color_extensions.dart';
+import 'package:wander_nest/shared/extensions/string_extension.dart';
+
+class CampsiteClusterPreviewList extends StatelessWidget {
+  const CampsiteClusterPreviewList({super.key, required this.campsites});
+
+  final List<Campsite> campsites;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final customColors = theme.extension<AppCustomColors>()!;
+
+    return Container(
+      height: 300,
+      padding: const EdgeInsets.all(AppSizes.padding),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(AppSizes.radius),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.alphaF(0.05),
+            blurRadius: AppSizes.spaceSM,
+            offset: const Offset(0, AppSizes.spaceXS),
+          ),
+        ],
+      ),
+      child: ListView.separated(
+        itemCount: campsites.length,
+        separatorBuilder: (_, __) => const SizedBox(height: AppSizes.spaceSM),
+        itemBuilder: (context, index) {
+          final campsite = campsites[index];
+
+          return Material(
+            borderRadius: BorderRadius.circular(AppSizes.radius),
+            color: colorScheme.surface,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(AppSizes.radius),
+              onTap: () {
+                Navigator.of(context).pop(); // Close the bottom sheet
+                // Navigate to the campsite detail screen
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => CampsiteDetailScreen(campsite: campsite),
+                  ),
+                );
+              },
+              child: Padding(
+                padding: const EdgeInsets.all(AppSizes.padding),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Thumbnail Image
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(AppSizes.radiusSM),
+                      child: Image.network(
+                        campsite.photo.secureUrl(),
+                        width: AppSizes.iconXXL,
+                        height: AppSizes.iconXXL,
+                        fit: BoxFit.cover,
+                        errorBuilder:
+                            (_, __, ___) => const Icon(
+                              Icons.image_not_supported,
+                              size: AppSizes.iconLG,
+                            ),
+                      ),
+                    ),
+                    const SizedBox(width: AppSizes.space),
+                    // Label & Price
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            campsite.label.capitalizeFirst(),
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: AppSizes.spaceXS),
+                          Text(
+                            '€${campsite.pricePerNight.toStringAsFixed(2)} / night',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.primary,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    // Features (Water, Campfire)
+                    Row(
+                      children: [
+                        Icon(
+                          AppIcons.water,
+                          size: AppSizes.iconLG,
+                          color:
+                              campsite.isCloseToWater
+                                  ? customColors.water
+                                  : customColors.disabled,
+                        ),
+                        const SizedBox(width: AppSizes.spaceSM),
+                        Icon(
+                          AppIcons.campfire,
+                          size: AppSizes.iconLG,
+                          color:
+                              campsite.isCampFireAllowed
+                                  ? customColors.fire
+                                  : customColors.disabled,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/maps/cluster_count_marker.dart
+++ b/lib/presentation/widgets/maps/cluster_count_marker.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/shared/extensions/color_extensions.dart';
+
+class ClusterCountMarker extends StatelessWidget {
+  const ClusterCountMarker(this.count, {super.key});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: AppSizes.iconLG,
+      height: AppSizes.iconLG,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: Colors.green.alphaF(0.75),
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.alphaF(0.25),
+            blurRadius: 6,
+            offset: const Offset(0, 2),
+          ),
+        ],
+        border: Border.all(color: Colors.white, width: 2),
+      ),
+      child: Text(
+        '$count',
+        style: const TextStyle(
+          fontSize: 16,
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION

- Implemented `MapControllerNotifier` with dynamic clustering logic
- Added `MapState` and `MapCluster` models to manage map data
- Created providers to supply cluster data and manage map state
- Built `MapScreen` with clustering and single marker display
- Added tap interaction: cluster shows campsite list, single marker navigates to detail