### PR TITLE
test: add unit tests for campsite list and filter providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+/coverage/

--- a/test/application/providers/campsite_provider_test.dart
+++ b/test/application/providers/campsite_provider_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:wander_nest/application/providers/campsite_provider.dart';
+import 'package:wander_nest/data/models/campsite.dart';
+import 'package:wander_nest/data/models/geo_location.dart';
+
+import '../../mocks/mocks.mocks.dart';
+
+void main() {
+  late MockCampsiteApiService mockApi;
+  late ProviderContainer container;
+
+  final mockCampsites = [
+    Campsite(
+      id: '1',
+      label: 'Beta Camp',
+      photo: 'url1',
+      isCloseToWater: true,
+      isCampFireAllowed: true,
+      hostLanguages: ['EN'],
+      pricePerNight: 500,
+      createdAt: DateTime.parse('2023-01-01'),
+      geoLocation: const GeoLocation(lat: 20.0, long: 30.0),
+    ),
+    Campsite(
+      id: '2',
+      label: 'Alpha Camp',
+      photo: 'url2',
+      isCloseToWater: false,
+      isCampFireAllowed: true,
+      hostLanguages: ['DE'],
+      pricePerNight: 700,
+      createdAt: DateTime.parse('2023-01-02'),
+      geoLocation: const GeoLocation(lat: 40.0, long: 50.0),
+    ),
+  ];
+
+  setUp(() {
+    mockApi = MockCampsiteApiService();
+
+    container = ProviderContainer(
+      overrides: [campsiteApiServiceProvider.overrideWithValue(mockApi)],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  group('campsiteListProvider', () {
+    test('returns data from mock API', () async {
+      when(mockApi.fetchCampsites()).thenAnswer((_) async => mockCampsites);
+
+      final result = await container.read(campsiteListProvider.future);
+
+      expect(result.length, 2);
+      expect(result[0].label, 'Beta Camp');
+      expect(result[1].label, 'Alpha Camp');
+    });
+
+    test('handles API error gracefully', () async {
+      when(mockApi.fetchCampsites()).thenThrow(Exception('API error'));
+
+      final asyncValue = await container
+          .read(campsiteListProvider.future)
+          .then<AsyncValue<List<Campsite>>>(
+            (_) => container.read(campsiteListProvider),
+            onError: (error) => container.read(campsiteListProvider),
+          );
+
+      expect(asyncValue, isA<AsyncValue<List<Campsite>>>());
+      expect(asyncValue.hasError, true);
+    });
+  });
+
+  group('sortedCampsiteListProvider', () {
+    test('returns list sorted by label', () async {
+      when(mockApi.fetchCampsites()).thenAnswer((_) async => mockCampsites);
+
+      await container.read(campsiteListProvider.future);
+      final sorted = container.read(sortedCampsiteListProvider);
+
+      expect(sorted.first.label, 'Alpha Camp');
+      expect(sorted.last.label, 'Beta Camp');
+    });
+
+    test('returns empty list when no data', () async {
+      when(mockApi.fetchCampsites()).thenAnswer((_) async => []);
+
+      await container.read(campsiteListProvider.future);
+      final sorted = container.read(sortedCampsiteListProvider);
+
+      expect(sorted, isEmpty);
+    });
+
+    test('does not mutate original list', () async {
+      when(mockApi.fetchCampsites()).thenAnswer((_) async => mockCampsites);
+
+      final original = List<Campsite>.from(mockCampsites);
+      await container.read(campsiteListProvider.future);
+      container.read(sortedCampsiteListProvider);
+
+      expect(mockCampsites[0].label, original[0].label);
+      expect(mockCampsites[1].label, original[1].label);
+    });
+  });
+
+  group('priceRangeProvider', () {
+    test('returns correct price range', () async {
+      when(mockApi.fetchCampsites()).thenAnswer((_) async => mockCampsites);
+
+      await container.read(campsiteListProvider.future);
+      final range = container.read(priceRangeProvider);
+
+      expect(range.start, 500);
+      expect(range.end, 700);
+    });
+
+    test('returns default range when no campsites', () async {
+      when(mockApi.fetchCampsites()).thenAnswer((_) async => []);
+
+      await container.read(campsiteListProvider.future);
+      final range = container.read(priceRangeProvider);
+
+      expect(range.start, 0);
+      expect(range.end, 1000);
+    });
+  });
+}

--- a/test/application/providers/filters/campsite_filter_model_test.dart
+++ b/test/application/providers/filters/campsite_filter_model_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_model.dart';
+
+void main() {
+  group('CampsiteFilter', () {
+    group('Empty filter', () {
+      test('has all fields null and isEmpty is true', () {
+        const filter = CampsiteFilter.empty;
+        expect(filter.isCloseToWater, isNull);
+        expect(filter.isCampFireAllowed, isNull);
+        expect(filter.hostLanguages, isNull);
+        expect(filter.priceRange, isNull);
+        expect(filter.isEmpty, isTrue);
+        expect(filter.hasAnyFilter, isFalse);
+        expect(filter.activeFilterCount, 0);
+      });
+    });
+
+    group('Active filter count', () {
+      test('filter with all fields set has correct activeFilterCount', () {
+        final filter = const CampsiteFilter(
+          isCloseToWater: true,
+          isCampFireAllowed: false,
+          hostLanguages: ['EN', 'FR'],
+          priceRange: RangeValues(10, 50),
+        );
+        expect(filter.activeFilterCount, 4);
+        expect(filter.isEmpty, isFalse);
+        expect(filter.hasAnyFilter, isTrue);
+      });
+
+      test('filter with only one field set', () {
+        final filter = const CampsiteFilter(isCloseToWater: true);
+        expect(filter.activeFilterCount, 1);
+        expect(filter.isEmpty, isFalse);
+        expect(filter.hasAnyFilter, isTrue);
+      });
+
+      test('hostLanguages empty list is not counted as active filter', () {
+        final filter = const CampsiteFilter(hostLanguages: []);
+        expect(filter.activeFilterCount, 0);
+        expect(filter.isEmpty, isTrue);
+        expect(filter.hasAnyFilter, isFalse);
+      });
+
+      test('hostLanguages null and empty are treated the same', () {
+        final filterNull = const CampsiteFilter(hostLanguages: null);
+        final filterEmpty = const CampsiteFilter(hostLanguages: []);
+        expect(filterNull.activeFilterCount, 0);
+        expect(filterEmpty.activeFilterCount, 0);
+      });
+    });
+
+    group('copyWith', () {
+      test('updates fields and resets correctly', () {
+        final filter = const CampsiteFilter(
+          isCloseToWater: true,
+          isCampFireAllowed: false,
+          hostLanguages: ['EN'],
+          priceRange: RangeValues(10, 20),
+        );
+
+        final updated = filter.copyWith(
+          isCloseToWater: false,
+          hostLanguages: ['DE', 'FR'],
+          priceRange: const RangeValues(30, 40),
+        );
+        expect(updated.isCloseToWater, false);
+        expect(updated.isCampFireAllowed, false);
+        expect(updated.hostLanguages, ['DE', 'FR']);
+        expect(updated.priceRange, const RangeValues(30, 40));
+
+        final reset = filter.copyWith(
+          resetCloseToWater: true,
+          resetCampFireAllowed: true,
+          resetHostLanguages: true,
+          resetPriceRange: true,
+        );
+        expect(reset.isCloseToWater, isNull);
+        expect(reset.isCampFireAllowed, isNull);
+        expect(reset.hostLanguages, isNull);
+        expect(reset.priceRange, isNull);
+        expect(reset.isEmpty, isTrue);
+      });
+
+      test('can set fields to null using reset flags', () {
+        final filter = const CampsiteFilter(isCampFireAllowed: true);
+        final updated = filter.copyWith(resetCampFireAllowed: true);
+        expect(updated.isCampFireAllowed, isNull);
+      });
+
+      test('does not reset fields unless reset flag is true', () {
+        final filter = const CampsiteFilter(isCloseToWater: true);
+        final updated = filter.copyWith();
+        expect(updated.isCloseToWater, true);
+      });
+
+      test('will update only the field that is within "copyWith"', () {
+        final filter = const CampsiteFilter(
+          isCloseToWater: true,
+          isCampFireAllowed: false,
+        );
+        final updated = filter.copyWith(isCampFireAllowed: true);
+        expect(updated.isCloseToWater, true);
+        expect(updated.isCampFireAllowed, true);
+      });
+    });
+  });
+}

--- a/test/application/providers/filters/campsite_filter_notifier_test.dart
+++ b/test/application/providers/filters/campsite_filter_notifier_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_model.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_notifier.dart';
+
+void main() {
+  group('CampsiteFilterNotifier', () {
+    late ProviderContainer container;
+    setUp(() {
+      container = ProviderContainer();
+    });
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('initial state is CampsiteFilter.empty', () {
+      final filter = container.read(campsiteFilterProvider);
+      expect(filter, CampsiteFilter.empty);
+    });
+
+    test('toggleWaterFilter sets isCloseToWater', () {
+      container.read(campsiteFilterProvider.notifier).toggleWaterFilter(true);
+      final filter = container.read(campsiteFilterProvider);
+      expect(filter.isCloseToWater, true);
+
+      container.read(campsiteFilterProvider.notifier).toggleWaterFilter(null);
+      final filter2 = container.read(campsiteFilterProvider);
+      expect(filter2.isCloseToWater, null);
+    });
+
+    test('toggleCampfireFilter sets isCampFireAllowed', () {
+      container
+          .read(campsiteFilterProvider.notifier)
+          .toggleCampfireFilter(false);
+      final filter = container.read(campsiteFilterProvider);
+      expect(filter.isCampFireAllowed, false);
+
+      container
+          .read(campsiteFilterProvider.notifier)
+          .toggleCampfireFilter(null);
+      final filter2 = container.read(campsiteFilterProvider);
+      expect(filter2.isCampFireAllowed, null);
+    });
+
+    test('updateHostLanguages sets hostLanguages', () {
+      container.read(campsiteFilterProvider.notifier).updateHostLanguages([
+        'en',
+        'fr',
+      ]);
+      final filter = container.read(campsiteFilterProvider);
+      expect(filter.hostLanguages, ['en', 'fr']);
+
+      container.read(campsiteFilterProvider.notifier).updateHostLanguages([]);
+      final filter2 = container.read(campsiteFilterProvider);
+      expect(filter2.hostLanguages, null);
+    });
+
+    test('updatePriceRange sets priceRange', () {
+      container
+          .read(campsiteFilterProvider.notifier)
+          .updatePriceRange(100, 500);
+      final filter = container.read(campsiteFilterProvider);
+      expect(filter.priceRange, const RangeValues(100, 500));
+
+      container
+          .read(campsiteFilterProvider.notifier)
+          .updatePriceRange(null, null);
+      final filter2 = container.read(campsiteFilterProvider);
+      expect(filter2.priceRange, null);
+    });
+
+    test('setFilter replaces state', () {
+      final newFilter = const CampsiteFilter(
+        isCloseToWater: true,
+        isCampFireAllowed: false,
+        hostLanguages: ['es'],
+        priceRange: RangeValues(200, 400),
+      );
+      container.read(campsiteFilterProvider.notifier).setFilter(newFilter);
+      final filter = container.read(campsiteFilterProvider);
+      expect(filter, newFilter);
+    });
+
+    test('resetFilters resets to empty', () {
+      container.read(campsiteFilterProvider.notifier).toggleWaterFilter(true);
+      container.read(campsiteFilterProvider.notifier).resetFilters();
+      final filter = container.read(campsiteFilterProvider);
+      expect(filter, CampsiteFilter.empty);
+    });
+  });
+}

--- a/test/application/providers/filters/filtered_campsites_provider_test.dart
+++ b/test/application/providers/filters/filtered_campsites_provider_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wander_nest/application/providers/campsite_provider.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_model.dart';
+import 'package:wander_nest/application/providers/filters/campsite_filter_notifier.dart';
+import 'package:wander_nest/application/providers/filters/filtered_campsites_provider.dart';
+import 'package:wander_nest/data/models/campsite.dart';
+import 'package:wander_nest/data/models/geo_location.dart';
+
+void main() {
+  final testCampsites = [
+    Campsite(
+      id: '1',
+      label: 'Alpha Camp',
+      isCloseToWater: true,
+      isCampFireAllowed: true,
+      hostLanguages: ['EN', 'DE'],
+      pricePerNight: 50,
+      photo: 'photo1.jpg',
+      createdAt: DateTime(2023, 1, 1),
+      geoLocation: const GeoLocation(lat: 0.0, long: 0.0),
+    ),
+    Campsite(
+      id: '2',
+      label: 'Delta Camp',
+      isCloseToWater: false,
+      isCampFireAllowed: false,
+      hostLanguages: ['French'],
+      pricePerNight: 30,
+      photo: 'photo2.jpg',
+      createdAt: DateTime(2023, 2, 1),
+      geoLocation: const GeoLocation(lat: 1.0, long: 1.0),
+    ),
+    Campsite(
+      id: '3',
+      label: 'Beta Camp',
+      isCloseToWater: false,
+      isCampFireAllowed: true,
+      hostLanguages: ['EN'],
+      pricePerNight: 80,
+      photo: 'photo3.jpg',
+      createdAt: DateTime(2023, 3, 1),
+      geoLocation: const GeoLocation(lat: 2.0, long: 2.0),
+    ),
+  ];
+
+  ProviderContainer makeContainer({
+    CampsiteFilter? filter,
+    List<Campsite>? campsites,
+  }) {
+    final container = ProviderContainer(
+      overrides: [
+        sortedCampsiteListProvider.overrideWithValue(
+          campsites ?? testCampsites,
+        ),
+        campsiteFilterProvider.overrideWith((ref) {
+          final notifier = CampsiteFilterNotifier();
+          notifier.state = filter ?? const CampsiteFilter();
+          return notifier;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('filteredCampsitesProvider', () {
+    test('returns all campsites when no filters are applied', () {
+      final container = makeContainer();
+      final result = container.read(filteredCampsitesProvider);
+      expect(result, testCampsites);
+    });
+
+    test('filters by isCloseToWater', () {
+      final filter = const CampsiteFilter(isCloseToWater: true);
+      final container = makeContainer(filter: filter);
+      final result = container.read(filteredCampsitesProvider);
+      expect(result.length, 1);
+      expect(result.first.label, 'Alpha Camp');
+    });
+
+    test('filters by isCampFireAllowed', () {
+      final filter = const CampsiteFilter(isCampFireAllowed: false);
+      final container = makeContainer(filter: filter);
+      final result = container.read(filteredCampsitesProvider);
+      expect(result.length, 1);
+      expect(result.first.label, 'Delta Camp');
+    });
+
+    test('filters by hostLanguages', () {
+      final filter = const CampsiteFilter(hostLanguages: ['DE']);
+      final container = makeContainer(filter: filter);
+      final result = container.read(filteredCampsitesProvider);
+      expect(result.length, 1);
+      expect(result.first.label, 'Alpha Camp');
+    });
+
+    test('filters by priceRange', () {
+      final filter = const CampsiteFilter(priceRange: RangeValues(40, 60));
+      final container = makeContainer(filter: filter);
+      final result = container.read(filteredCampsitesProvider);
+      expect(result.length, 1);
+      expect(result.first.label, 'Alpha Camp');
+    });
+
+    test('applies multiple filters together', () {
+      final filter = const CampsiteFilter(
+        isCloseToWater: false,
+        isCampFireAllowed: true,
+        hostLanguages: ['EN'],
+        priceRange: RangeValues(70, 90),
+      );
+      final container = makeContainer(filter: filter);
+      final result = container.read(filteredCampsitesProvider);
+      expect(result.length, 1);
+      expect(result.first.label, 'Beta Camp');
+    });
+
+    test('returns empty list when no campsites match', () {
+      final filter = const CampsiteFilter(
+        isCloseToWater: true,
+        isCampFireAllowed: false,
+      );
+      final container = makeContainer(filter: filter);
+      final result = container.read(filteredCampsitesProvider);
+      expect(result, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
- Modified .gitignore for improved ignores
- Verified campsite list providers including sorting and price range computations
- Covered filter-related models, notifiers, and providers with unit tests