### PR TITLE
refactor(map): cluster update flow & fix web tile provider

### DIFF
--- a/lib/features/maps/presentation/providers/map_providers.dart
+++ b/lib/features/maps/presentation/providers/map_providers.dart
@@ -1,9 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wander_nest/features/maps/domain/entities/map_cluster.dart';
 import 'package:wander_nest/features/maps/presentation/providers/map_controller_notifier.dart';
 import 'package:wander_nest/features/maps/presentation/providers/map_state.dart';
-import 'package:wander_nest/shared/providers/filtered_campsites_provider.dart';
 
 final mapControllerProvider =
     StateNotifierProvider<MapControllerNotifier, MapState>(
@@ -12,19 +10,6 @@ final mapControllerProvider =
 
 // Watches filtered campsites and triggers cluster generation on zoom change
 final mapClustersProvider = Provider<AsyncValue<List<MapCluster>>>((ref) {
-  final campsites = ref.watch(filteredCampsitesProvider);
   final mapState = ref.watch(mapControllerProvider);
-
-  if (campsites.isEmpty) {
-    return const AsyncValue.data([]);
-  }
-
-  // Trigger cluster update after build
-  WidgetsBinding.instance.addPostFrameCallback((_) {
-    ref
-        .read(mapControllerProvider.notifier)
-        .updateClusters(campsites, mapState.currentZoom);
-  });
-
   return AsyncValue.data(mapState.clusters);
 });

--- a/lib/features/maps/presentation/widgets/campsite_detail_map.dart
+++ b/lib/features/maps/presentation/widgets/campsite_detail_map.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart';
 import 'package:wander_nest/core/constants/app_sizes.dart';
 import 'package:wander_nest/features/campsite/data/models/campsite.dart';
 import 'package:wander_nest/features/maps/presentation/widgets/campsite_marker_icon.dart';
@@ -27,6 +29,10 @@ class CampsiteDetailMap extends StatelessWidget {
               ),
               children: [
                 TileLayer(
+                  tileProvider:
+                      kIsWeb
+                          ? CancellableNetworkTileProvider()
+                          : NetworkTileProvider(),
                   urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
                   userAgentPackageName: 'com.example.wanderNest',
                 ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -230,6 +246,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.1"
+  flutter_map_cancellable_tile_provider:
+    dependency: "direct main"
+    description:
+      name: flutter_map_cancellable_tile_provider
+      sha256: "582df422f65c68216fcbc8f2d2c335ff3e8a014d9815382cfdde23ef772b4fb0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_map: ^8.1.1
   latlong2: ^0.9.1
   flutter_staggered_animations: ^1.1.1
+  flutter_map_cancellable_tile_provider: ^3.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Moved `addPostFrameCallback` from provider to MapScreen build logic to ensure clusters are updated only after the required state is available, avoiding lifecycle-related errors.
- Fixed `flutter_map` tile warning on web by using `CancellableNetworkTileProvider` conditionally for better performance and responsiveness.