### PR TITLE
refactor(ui): extract campsite detail methods into widgets

### DIFF
--- a/lib/core/widgets/buttons/primary_button.dart
+++ b/lib/core/widgets/buttons/primary_button.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+
+class PrimaryButton extends StatelessWidget {
+  const PrimaryButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.fullWidth = true,
+    this.safeArea = true,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final bool fullWidth;
+  final bool safeArea;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
+    final button = SizedBox(
+      height: AppSizes.buttonHeight,
+      width: fullWidth ? double.infinity : null,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          padding: const EdgeInsets.symmetric(horizontal: AppSizes.padding),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppSizes.radius),
+          ),
+          backgroundColor: colors.primary,
+          foregroundColor: colors.onPrimary,
+          textStyle: Theme.of(context).textTheme.titleMedium,
+        ),
+        child: Text(label),
+      ),
+    );
+
+    return safeArea
+        ? SafeArea(
+          minimum: const EdgeInsets.all(AppSizes.padding),
+          child: button,
+        )
+        : button;
+  }
+}

--- a/lib/features/campsite/presentation/screens/campsite_detail_screen.dart
+++ b/lib/features/campsite/presentation/screens/campsite_detail_screen.dart
@@ -14,13 +14,25 @@ class CampsiteDetailScreen extends StatelessWidget {
 
   static const double _maxMapWidth = 600;
 
+  void _handleBookNowAction(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Booking not implemented yet'),
+        duration: Duration(seconds: 2),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final campsiteName = campsite.label.capitalizeFirst();
 
     return Scaffold(
       appBar: AppBar(title: Text(campsiteName)),
-      bottomNavigationBar: const _BookNowButton(),
+      bottomNavigationBar: PrimaryButton(
+        label: 'Book Now',
+        onPressed: () => _handleBookNowAction,
+      ),
       body: LayoutBuilder(
         builder: (context, constraints) {
           return SingleChildScrollView(
@@ -108,25 +120,6 @@ class CampsiteDetailScreen extends StatelessWidget {
 
 // Note: Below widges are currently local to this file for cohesion.
 // Can be extracted into its own file later if reused elsewhere.
-
-class _BookNowButton extends StatelessWidget {
-  const _BookNowButton();
-
-  @override
-  Widget build(BuildContext context) {
-    return PrimaryButton(
-      label: 'Book Now',
-      onPressed: () {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Booking not implemented yet'),
-            duration: Duration(seconds: 2),
-          ),
-        );
-      },
-    );
-  }
-}
 
 class _CampsiteHeroImage extends StatelessWidget {
   const _CampsiteHeroImage({required this.imageUrl, required this.maxWidth});

--- a/lib/features/campsite/presentation/screens/campsite_detail_screen.dart
+++ b/lib/features/campsite/presentation/screens/campsite_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:wander_nest/core/constants/app_icons.dart';
 import 'package:wander_nest/core/constants/app_sizes.dart';
 import 'package:wander_nest/core/themes/app_custom_colors.dart';
+import 'package:wander_nest/core/widgets/buttons/primary_button.dart';
 import 'package:wander_nest/features/campsite/data/models/campsite.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/campsite_feature_badge.dart';
 import 'package:wander_nest/features/maps/presentation/widgets/campsite_detail_map.dart';
@@ -15,14 +16,11 @@ class CampsiteDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colors = theme.colorScheme;
-    final customColors = Theme.of(context).extension<AppCustomColors>()!;
     final campsiteName = campsite.label.capitalizeFirst();
 
     return Scaffold(
       appBar: AppBar(title: Text(campsiteName)),
-      bottomNavigationBar: _buildBookNowButton(context, colors),
+      bottomNavigationBar: const _BookNowButton(),
       body: LayoutBuilder(
         builder: (context, constraints) {
           return SingleChildScrollView(
@@ -44,7 +42,10 @@ class CampsiteDetailScreen extends StatelessWidget {
                             flex: 3,
                             child: Column(
                               children: [
-                                _buildHeroImage(campsite),
+                                _CampsiteHeroImage(
+                                  imageUrl: campsite.photo.secureUrl(),
+                                  maxWidth: _maxMapWidth,
+                                ),
                                 const SizedBox(height: AppSizes.spaceLG),
                                 CampsiteDetailMap(campsite: campsite),
                               ],
@@ -57,12 +58,13 @@ class CampsiteDetailScreen extends StatelessWidget {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                _buildPrice(theme, colors),
+                                _CampsitePriceText(
+                                  pricePerNight: campsite.pricePerNight,
+                                ),
                                 const SizedBox(height: AppSizes.spaceSM),
-                                _buildFeatureBadges(campsite, customColors),
+                                _CampsiteFeatureBadges(campsite: campsite),
                                 const SizedBox(height: AppSizes.spaceLG),
-                                _buildDescription(
-                                  theme,
+                                _CampsiteDescriptionText(
                                   campsiteName: campsiteName,
                                 ),
                               ],
@@ -77,16 +79,18 @@ class CampsiteDetailScreen extends StatelessWidget {
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      _buildHeroImage(campsite),
+                      _CampsiteHeroImage(
+                        imageUrl: campsite.photo,
+                        maxWidth: _maxMapWidth,
+                      ),
                       const SizedBox(height: AppSizes.spaceLG),
                       CampsiteDetailMap(campsite: campsite),
                       const SizedBox(height: AppSizes.spaceLG),
-                      _buildPrice(theme, colors),
+                      _CampsitePriceText(pricePerNight: campsite.pricePerNight),
                       const SizedBox(height: AppSizes.spaceSM),
-                      _buildFeatureBadges(campsite, customColors),
+                      _CampsiteFeatureBadges(campsite: campsite),
                       const SizedBox(height: AppSizes.spaceLG),
-                      _buildDescription(
-                        theme,
+                      _CampsiteDescriptionText(
                         campsiteName: campsiteName,
                         isWide: false,
                       ),
@@ -100,69 +104,45 @@ class CampsiteDetailScreen extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildPrice(ThemeData theme, ColorScheme colors) {
-    return Text(
-      '€${campsite.pricePerNight.toStringAsFixed(2)} / night',
-      style: theme.textTheme.headlineSmall?.copyWith(
-        color: colors.primary,
-        fontWeight: FontWeight.bold,
-      ),
-    );
-  }
+// Note: Below widges are currently local to this file for cohesion.
+// Can be extracted into its own file later if reused elsewhere.
 
-  Widget _buildDescription(
-    ThemeData theme, {
-    required String campsiteName,
-    bool isWide = true,
-  }) {
-    return Text(
-      'Enjoy scenic nature and outdoor adventures with our premium campsite "$campsiteName"',
-      style: theme.textTheme.bodyLarge,
-      textAlign: isWide ? TextAlign.start : TextAlign.center,
-    );
-  }
+class _BookNowButton extends StatelessWidget {
+  const _BookNowButton();
 
-  Widget _buildBookNowButton(BuildContext context, ColorScheme colors) {
-    return SafeArea(
-      minimum: const EdgeInsets.all(AppSizes.padding),
-      child: SizedBox(
-        height: AppSizes.buttonHeight,
-        width: double.infinity,
-        child: ElevatedButton(
-          onPressed: () {
-            // Handle booking action
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('Booking not implemented yet'),
-                duration: Duration(seconds: 2),
-              ),
-            );
-          },
-          style: ElevatedButton.styleFrom(
-            padding: const EdgeInsets.symmetric(horizontal: AppSizes.padding),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(AppSizes.radius),
-            ),
-            backgroundColor: colors.primary,
-            foregroundColor: colors.onPrimary,
-            textStyle: Theme.of(context).textTheme.titleMedium,
+  @override
+  Widget build(BuildContext context) {
+    return PrimaryButton(
+      label: 'Book Now',
+      onPressed: () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Booking not implemented yet'),
+            duration: Duration(seconds: 2),
           ),
-          child: const Text('Book Now'),
-        ),
-      ),
+        );
+      },
     );
   }
+}
 
-  Widget _buildHeroImage(Campsite campsite) {
+class _CampsiteHeroImage extends StatelessWidget {
+  const _CampsiteHeroImage({required this.imageUrl, required this.maxWidth});
+  final String imageUrl;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
     return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: _maxMapWidth),
+      constraints: BoxConstraints(maxWidth: maxWidth),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(AppSizes.radius),
         child: AspectRatio(
           aspectRatio: 16 / 9,
           child: Image.network(
-            campsite.photo.secureUrl(),
+            imageUrl,
             width: double.infinity,
             fit: BoxFit.cover,
             errorBuilder:
@@ -173,8 +153,54 @@ class CampsiteDetailScreen extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildFeatureBadges(Campsite campsite, AppCustomColors customColors) {
+class _CampsitePriceText extends StatelessWidget {
+  const _CampsitePriceText({required this.pricePerNight});
+  final double pricePerNight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return Text(
+      '€${pricePerNight.toStringAsFixed(2)} / night',
+      style: theme.textTheme.headlineSmall?.copyWith(
+        color: colors.primary,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+}
+
+class _CampsiteDescriptionText extends StatelessWidget {
+  const _CampsiteDescriptionText({
+    required this.campsiteName,
+    this.isWide = true,
+  });
+  final String campsiteName;
+  final bool isWide;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      'Enjoy scenic nature and outdoor adventures with our premium campsite "$campsiteName"',
+      style: theme.textTheme.bodyLarge,
+      textAlign: isWide ? TextAlign.start : TextAlign.center,
+    );
+  }
+}
+
+class _CampsiteFeatureBadges extends StatelessWidget {
+  const _CampsiteFeatureBadges({required this.campsite});
+  final Campsite campsite;
+
+  @override
+  Widget build(BuildContext context) {
+    final customColors = Theme.of(context).extension<AppCustomColors>()!;
+
     return Wrap(
       spacing: AppSizes.spaceSM,
       runSpacing: AppSizes.spaceSM,

--- a/lib/features/campsite/presentation/screens/home_screen.dart
+++ b/lib/features/campsite/presentation/screens/home_screen.dart
@@ -12,6 +12,25 @@ import 'package:wander_nest/shared/providers/filtered_campsites_provider.dart';
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
+  void _handleMapIconPressed(
+    BuildContext context, {
+    required bool isCampsitesEmpty,
+  }) {
+    if (isCampsitesEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('No campsites to display on the map'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    } else {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (_) => const MapScreen()),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final campsiteListAsync = ref.watch(campsiteListProvider);
@@ -22,7 +41,16 @@ class HomeScreen extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('Wander Nest'),
         actions: [
-          _buildMapIconButton(context, filteredCampsites.isEmpty),
+          // View Map
+          IconButton(
+            icon: const Icon(Icons.map),
+            onPressed: () {
+              _handleMapIconPressed(
+                context,
+                isCampsitesEmpty: filteredCampsites.isEmpty,
+              );
+            },
+          ),
           if (isCompact)
             /// Compact view: Show filter icon with badge
             FilterActionIcon(
@@ -57,27 +85,6 @@ class HomeScreen extends ConsumerWidget {
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildMapIconButton(BuildContext context, bool isCampsitesEmpty) {
-    return IconButton(
-      icon: const Icon(Icons.map),
-      onPressed: () {
-        if (isCampsitesEmpty) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('No campsites to display on map'),
-              duration: Duration(seconds: 2),
-            ),
-          );
-          return;
-        }
-        Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const MapScreen()),
-        );
-      },
     );
   }
 }


### PR DESCRIPTION
- Extracted `_buildX()` methods into individual reusable widgets to improve readability, testability, and separation of concerns. 
> Note: These widgets can be moved to separate files later if reused in other screens or contexts.

- Created a common `PrimaryButton`.