### PR TITLE
feat: add favourites feature with reusable animated views and tests

### DIFF
--- a/lib/core/constants/app_icons.dart
+++ b/lib/core/constants/app_icons.dart
@@ -6,5 +6,8 @@ class AppIcons {
   static const IconData campfire = Icons.local_fire_department;
   static const IconData language = Icons.language;
   static const IconData filter = Icons.filter_list;
+  static const IconData map = Icons.map;
   static const IconData mapMarker = Icons.park;
+  static const IconData favorite = Icons.favorite;
+  static const IconData favoriteBorder = Icons.favorite_border;
 }

--- a/lib/features/campsite/presentation/screens/campsite_detail_screen.dart
+++ b/lib/features/campsite/presentation/screens/campsite_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:wander_nest/core/themes/app_custom_colors.dart';
 import 'package:wander_nest/core/widgets/buttons/primary_button.dart';
 import 'package:wander_nest/features/campsite/domain/entities/campsite.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/campsite_feature_badge.dart';
+import 'package:wander_nest/features/favourites/presentation/widgets/favourite_button.dart';
 import 'package:wander_nest/features/maps/presentation/widgets/campsite_detail_map.dart';
 
 class CampsiteDetailScreen extends StatelessWidget {
@@ -27,7 +28,10 @@ class CampsiteDetailScreen extends StatelessWidget {
     final campsiteName = campsite.name;
 
     return Scaffold(
-      appBar: AppBar(title: Text(campsiteName)),
+      appBar: AppBar(
+        title: Text(campsiteName),
+        actions: [FavouriteButton(campsiteId: campsite.id)],
+      ),
       bottomNavigationBar: PrimaryButton(
         label: 'Book Now',
         onPressed: () => _handleBookNowAction(context),

--- a/lib/features/campsite/presentation/screens/home_screen.dart
+++ b/lib/features/campsite/presentation/screens/home_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/core/constants/app_icons.dart';
 import 'package:wander_nest/features/campsite/presentation/providers/campsite_provider.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/app_error_message.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/app_tagline_banner.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/responsive_campsite_view.dart';
+import 'package:wander_nest/features/favourites/presentation/screens/favourite_campsites_page.dart';
 import 'package:wander_nest/features/filters/presentation/widgets/filter_action_icon.dart';
 import 'package:wander_nest/features/filters/presentation/widgets/filter_overlay_panel.dart';
 import 'package:wander_nest/features/maps/presentation/screens/map_screen.dart';
@@ -44,7 +46,7 @@ class HomeScreen extends ConsumerWidget {
         actions: [
           // View Map
           IconButton(
-            icon: const Icon(Icons.map),
+            icon: const Icon(AppIcons.map),
             onPressed: () {
               _handleMapIconPressed(
                 context,
@@ -62,6 +64,17 @@ class HomeScreen extends ConsumerWidget {
                     builder: (_) => const FilterOverlayPanel(),
                   ),
             ),
+          IconButton(
+            icon: const Icon(AppIcons.favorite),
+            tooltip: 'View favourites',
+            onPressed:
+                () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const FavouriteCampsitesPage(),
+                  ),
+                ),
+          ),
         ],
       ),
       body: Column(

--- a/lib/features/campsite/presentation/widgets/campsite_card.dart
+++ b/lib/features/campsite/presentation/widgets/campsite_card.dart
@@ -3,6 +3,7 @@ import 'package:wander_nest/core/constants/app_sizes.dart';
 import 'package:wander_nest/features/campsite/domain/entities/campsite.dart';
 import 'package:wander_nest/features/campsite/presentation/navigation/campsite_routes.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/campsite_feature_row.dart';
+import 'package:wander_nest/features/favourites/presentation/widgets/favourite_button.dart';
 
 class CampsiteCard extends StatelessWidget {
   const CampsiteCard({super.key, required this.campsite});
@@ -30,16 +31,26 @@ class CampsiteCard extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 // Image
-                AspectRatio(
-                  aspectRatio: 16 / 9,
-                  child: Image.network(
-                    campsite.photoUrl,
-                    fit: BoxFit.cover,
-                    errorBuilder:
-                        (context, error, stackTrace) => const Center(
-                          child: Icon(Icons.image_not_supported),
-                        ),
-                  ),
+                Stack(
+                  children: [
+                    AspectRatio(
+                      aspectRatio: 16 / 9,
+                      child: Image.network(
+                        campsite.photoUrl,
+                        fit: BoxFit.cover,
+                        errorBuilder:
+                            (context, error, stackTrace) => const Center(
+                              child: Icon(Icons.image_not_supported),
+                            ),
+                      ),
+                    ),
+
+                    Positioned(
+                      top: AppSizes.spaceSM,
+                      right: AppSizes.spaceSM,
+                      child: FavouriteButton(campsiteId: campsite.id),
+                    ),
+                  ],
                 ),
 
                 Padding(

--- a/lib/features/campsite/presentation/widgets/home_compact_layout.dart
+++ b/lib/features/campsite/presentation/widgets/home_compact_layout.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
 import 'package:wander_nest/core/constants/app_sizes.dart';
 import 'package:wander_nest/features/campsite/domain/entities/campsite.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/campsite_card.dart';
@@ -9,6 +8,7 @@ import 'package:wander_nest/features/campsite/presentation/widgets/result_summar
 import 'package:wander_nest/features/filters/domain/entities/filter_state.dart';
 import 'package:wander_nest/features/filters/presentation/providers/campsite_filter_notifier.dart';
 import 'package:wander_nest/features/filters/presentation/widgets/active_filter_chips.dart';
+import 'package:wander_nest/shared/widgets/animated_lists.dart';
 
 class HomeCompactLayout extends ConsumerWidget {
   const HomeCompactLayout({
@@ -27,23 +27,9 @@ class HomeCompactLayout extends ConsumerWidget {
     Widget content = const NoCampsiteFound();
 
     if (filteredCampsites.isNotEmpty) {
-      content = AnimationLimiter(
-        child: ListView.separated(
-          padding: const EdgeInsets.all(AppSizes.padding),
-          itemCount: filteredCampsites.length,
-          separatorBuilder: (_, __) => const SizedBox(height: AppSizes.space),
-          itemBuilder: (context, index) {
-            final campsite = filteredCampsites[index];
-            return AnimationConfiguration.staggeredList(
-              position: index,
-              duration: const Duration(milliseconds: 400),
-              child: SlideAnimation(
-                verticalOffset: 50.0,
-                child: FadeInAnimation(child: CampsiteCard(campsite: campsite)),
-              ),
-            );
-          },
-        ),
+      content = AnimatedListView<Campsite>(
+        items: filteredCampsites,
+        itemBuilder: (context, campsite) => CampsiteCard(campsite: campsite),
       );
     }
 

--- a/lib/features/campsite/presentation/widgets/home_wide_layout.dart
+++ b/lib/features/campsite/presentation/widgets/home_wide_layout.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
 import 'package:wander_nest/core/constants/app_sizes.dart';
 import 'package:wander_nest/features/campsite/domain/entities/campsite.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/campsite_card.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/home_empty_campsite.dart';
 import 'package:wander_nest/features/campsite/presentation/widgets/result_summary_banner.dart';
 import 'package:wander_nest/features/filters/presentation/widgets/filter_sidebar_panel.dart';
+import 'package:wander_nest/shared/widgets/animated_lists.dart';
 
 class HomeWideLayout extends ConsumerWidget {
   const HomeWideLayout({
@@ -24,7 +24,6 @@ class HomeWideLayout extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final filterPanelWidth = 300;
     final availableWidth = width - filterPanelWidth;
-    final crossAxisCount = availableWidth ~/ 300;
 
     return Padding(
       padding: const EdgeInsets.all(AppSizes.padding),
@@ -55,29 +54,12 @@ class HomeWideLayout extends ConsumerWidget {
                   const Expanded(child: NoCampsiteFound())
                 else
                   Expanded(
-                    child: AnimationLimiter(
-                      child: GridView.builder(
-                        itemCount: filteredCampsites.length,
-                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: crossAxisCount,
-                          mainAxisSpacing: AppSizes.space,
-                          crossAxisSpacing: AppSizes.space,
-                          childAspectRatio: 0.95,
-                        ),
-                        itemBuilder: (context, index) {
-                          final campsite = filteredCampsites[index];
-                          return AnimationConfiguration.staggeredGrid(
-                            position: index,
-                            duration: const Duration(milliseconds: 500),
-                            columnCount: crossAxisCount,
-                            child: ScaleAnimation(
-                              child: FadeInAnimation(
-                                child: CampsiteCard(campsite: campsite),
-                              ),
-                            ),
-                          );
-                        },
-                      ),
+                    child: AnimatedGridView<Campsite>(
+                      items: filteredCampsites,
+                      maxWidth: availableWidth,
+                      itemBuilder:
+                          (context, campsite) =>
+                              CampsiteCard(campsite: campsite),
                     ),
                   ),
               ],

--- a/lib/features/favourites/data/repositories/favourites_repository_impl.dart
+++ b/lib/features/favourites/data/repositories/favourites_repository_impl.dart
@@ -1,0 +1,20 @@
+import 'package:wander_nest/features/favourites/domain/repositories/favourites_repository.dart';
+
+class FavouritesRepositoryImpl implements FavouritesRepository {
+  final Set<String> _favouriteIds = {};
+
+  @override
+  Set<String> getFavouriteIds() => _favouriteIds;
+
+  @override
+  bool isFavourite(String campsiteId) => _favouriteIds.contains(campsiteId);
+
+  @override
+  void toggleFavourite(String campsiteId) {
+    if (_favouriteIds.contains(campsiteId)) {
+      _favouriteIds.remove(campsiteId);
+    } else {
+      _favouriteIds.add(campsiteId);
+    }
+  }
+}

--- a/lib/features/favourites/domain/repositories/favourites_repository.dart
+++ b/lib/features/favourites/domain/repositories/favourites_repository.dart
@@ -1,0 +1,5 @@
+abstract class FavouritesRepository {
+  Set<String> getFavouriteIds();
+  bool isFavourite(String campsiteId);
+  void toggleFavourite(String campsiteId);
+}

--- a/lib/features/favourites/domain/usecases/toggle_favourite_use_case.dart
+++ b/lib/features/favourites/domain/usecases/toggle_favourite_use_case.dart
@@ -1,0 +1,10 @@
+import 'package:wander_nest/features/favourites/domain/repositories/favourites_repository.dart';
+
+class ToggleFavouriteUseCase {
+  ToggleFavouriteUseCase(this.repository);
+  final FavouritesRepository repository;
+
+  void call(String campsiteId) {
+    repository.toggleFavourite(campsiteId);
+  }
+}

--- a/lib/features/favourites/presentation/providers/favourites_provider.dart
+++ b/lib/features/favourites/presentation/providers/favourites_provider.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/features/favourites/data/repositories/favourites_repository_impl.dart';
+import 'package:wander_nest/features/favourites/domain/repositories/favourites_repository.dart';
+import 'package:wander_nest/features/favourites/domain/usecases/toggle_favourite_use_case.dart';
+
+final favouritesRepositoryProvider = Provider<FavouritesRepository>(
+  (ref) => FavouritesRepositoryImpl(),
+);
+
+final toggleFavouriteUseCaseProvider = Provider<ToggleFavouriteUseCase>(
+  (ref) => ToggleFavouriteUseCase(ref.read(favouritesRepositoryProvider)),
+);
+
+final favouritesProvider =
+    StateNotifierProvider<FavouritesNotifier, Set<String>>(
+      (ref) => FavouritesNotifier(ref.read(favouritesRepositoryProvider)),
+    );
+
+class FavouritesNotifier extends StateNotifier<Set<String>> {
+  FavouritesNotifier(this.repository) : super(repository.getFavouriteIds());
+
+  final FavouritesRepository repository;
+
+  void toggleFavourite(String id) {
+    repository.toggleFavourite(id);
+    state = {...repository.getFavouriteIds()}; // trigger a rebuild
+  }
+
+  bool isFavourite(String id) => state.contains(id);
+}

--- a/lib/features/favourites/presentation/screens/favourite_campsites_page.dart
+++ b/lib/features/favourites/presentation/screens/favourite_campsites_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/features/campsite/domain/entities/campsite.dart';
+import 'package:wander_nest/features/campsite/presentation/providers/campsite_provider.dart';
+import 'package:wander_nest/features/campsite/presentation/widgets/campsite_card.dart';
+import 'package:wander_nest/features/favourites/presentation/providers/favourites_provider.dart';
+import 'package:wander_nest/shared/widgets/animated_lists.dart';
+
+class FavouriteCampsitesPage extends ConsumerWidget {
+  const FavouriteCampsitesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final allCampsites = ref.watch(sortedCampsiteListProvider);
+    final favouriteIds = ref.watch(favouritesProvider).toSet();
+
+    final favourites =
+        allCampsites
+            .where((campsite) => favouriteIds.contains(campsite.id))
+            .toList();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Your Favourites')),
+      body:
+          favourites.isEmpty
+              ? const Center(
+                child: Text('No favourites yet. Tap the heart icon to add.'),
+              )
+              : LayoutBuilder(
+                builder: (context, constraints) {
+                  final isWide = constraints.maxWidth > 600;
+                  return isWide
+                      ? AnimatedGridView<Campsite>(
+                        items: favourites,
+                        maxWidth: constraints.maxWidth,
+                        itemBuilder:
+                            (context, campsite) =>
+                                CampsiteCard(campsite: campsite),
+                      )
+                      : AnimatedListView<Campsite>(
+                        items: favourites,
+                        itemBuilder:
+                            (context, campsite) =>
+                                CampsiteCard(campsite: campsite),
+                      );
+                },
+              ),
+    );
+  }
+}

--- a/lib/features/favourites/presentation/widgets/favourite_button.dart
+++ b/lib/features/favourites/presentation/widgets/favourite_button.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wander_nest/core/constants/app_icons.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+import 'package:wander_nest/shared/extensions/color_extensions.dart';
+import '../providers/favourites_provider.dart';
+
+class FavouriteButton extends ConsumerWidget {
+  const FavouriteButton({
+    super.key,
+    required this.campsiteId,
+    this.size = AppSizes.icon,
+  });
+
+  final String campsiteId;
+  final double size;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isFav = ref.watch(favouritesProvider).contains(campsiteId);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black.alphaF(0.4),
+        shape: BoxShape.circle,
+        boxShadow: [BoxShadow(color: Colors.black.alphaF(0.1), blurRadius: 4)],
+      ),
+      child: IconButton(
+        icon: Icon(
+          isFav ? AppIcons.favorite : AppIcons.favoriteBorder,
+          color: isFav ? Colors.redAccent : Colors.white.alphaF(0.8),
+          size: size,
+        ),
+        tooltip: isFav ? 'Remove from favourites' : 'Add to favourites',
+        onPressed:
+            () => ref
+                .read(favouritesProvider.notifier)
+                .toggleFavourite(campsiteId),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/animated_lists.dart
+++ b/lib/shared/widgets/animated_lists.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
+import 'package:wander_nest/core/constants/app_sizes.dart';
+
+/// A generic animated grid view that adapts the number of columns based on [maxWidth].
+/// Use [itemBuilder] to build the widget for each item.
+///
+/// Example usage:
+/// ```dart
+/// AnimatedGridView<Campsite>(
+///   items: campsiteList,
+///   maxWidth: MediaQuery.of(context).size.width,
+///   itemBuilder: (context, campsite) => CampsiteCard(campsite: campsite),
+/// )
+/// ```
+class AnimatedGridView<T> extends StatelessWidget {
+  const AnimatedGridView({
+    super.key,
+    required this.items,
+    required this.itemBuilder,
+    required this.maxWidth,
+  });
+
+  final List<T> items;
+  final Widget Function(BuildContext context, T item) itemBuilder;
+  final double maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final crossAxisCount = maxWidth ~/ 300;
+
+    return AnimationLimiter(
+      child: GridView.builder(
+        padding: const EdgeInsets.all(AppSizes.padding),
+        itemCount: items.length,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: crossAxisCount,
+          mainAxisSpacing: AppSizes.space,
+          crossAxisSpacing: AppSizes.space,
+          childAspectRatio: 0.95,
+        ),
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return AnimationConfiguration.staggeredGrid(
+            position: index,
+            duration: const Duration(milliseconds: 500),
+            columnCount: crossAxisCount,
+            child: ScaleAnimation(
+              child: FadeInAnimation(child: itemBuilder(context, item)),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// A generic animated list view with staggered animations.
+/// Use [itemBuilder] to build the widget for each item.
+///
+/// Example usage:
+/// ```dart
+/// AnimatedListView<Campsite>(
+///   items: campsiteList,
+///   itemBuilder: (context, campsite) => CampsiteCard(campsite: campsite),
+/// )
+/// ```
+class AnimatedListView<T> extends StatelessWidget {
+  const AnimatedListView({
+    super.key,
+    required this.items,
+    required this.itemBuilder,
+  });
+
+  final List<T> items;
+  final Widget Function(BuildContext context, T item) itemBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimationLimiter(
+      child: ListView.separated(
+        padding: const EdgeInsets.all(AppSizes.padding),
+        itemCount: items.length,
+        separatorBuilder: (_, __) => const SizedBox(height: AppSizes.space),
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return AnimationConfiguration.staggeredList(
+            position: index,
+            duration: const Duration(milliseconds: 400),
+            child: SlideAnimation(
+              verticalOffset: 50.0,
+              child: FadeInAnimation(child: itemBuilder(context, item)),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/test/features/favourites/data/repositories/favourites_repository_impl_test.dart
+++ b/test/features/favourites/data/repositories/favourites_repository_impl_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wander_nest/features/favourites/data/repositories/favourites_repository_impl.dart';
+import 'package:wander_nest/features/favourites/domain/repositories/favourites_repository.dart';
+
+void main() {
+  group('FavouritesRepositoryImpl', () {
+    late FavouritesRepository repository;
+
+    setUp(() {
+      repository = FavouritesRepositoryImpl();
+    });
+
+    test('initial favourites set is empty', () {
+      expect(repository.getFavouriteIds(), isEmpty);
+    });
+
+    test('toggleFavourite adds an ID if not present', () {
+      const id = 'campId1';
+      expect(repository.getFavouriteIds(), isEmpty);
+
+      repository.toggleFavourite(id);
+
+      expect(repository.getFavouriteIds(), contains(id));
+      expect(repository.isFavourite(id), isTrue);
+    });
+
+    test('toggleFavourite removes an ID if already present', () {
+      const id = 'campId1';
+
+      repository.toggleFavourite(id); // add
+      repository.toggleFavourite(id); // remove
+
+      expect(repository.getFavouriteIds(), isNot(contains(id)));
+      expect(repository.isFavourite(id), isFalse);
+    });
+
+    test(
+      'toggleFavourite handles add and remove when there are multiple favourites',
+      () {
+        repository.toggleFavourite('campId1');
+        repository.toggleFavourite('campId2');
+
+        expect(
+          repository.getFavouriteIds(),
+          containsAll(['campId1', 'campId2']),
+        );
+        expect(repository.isFavourite('campId1'), isTrue);
+
+        repository.toggleFavourite('campId1');
+        expect(repository.isFavourite('campId1'), isFalse);
+      },
+    );
+  });
+}

--- a/test/features/favourites/domain/usecases/toggle_favourite_use_case_test.dart
+++ b/test/features/favourites/domain/usecases/toggle_favourite_use_case_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:wander_nest/features/favourites/domain/usecases/toggle_favourite_use_case.dart';
+
+import '../../../../mocks/mocks.mocks.dart';
+
+void main() {
+  late MockFavouritesRepository mockRepository;
+  late ToggleFavouriteUseCase toggleFavouriteUseCase;
+
+  setUp(() {
+    mockRepository = MockFavouritesRepository();
+    toggleFavouriteUseCase = ToggleFavouriteUseCase(mockRepository);
+  });
+
+  group('ToggleFavouriteUseCase', () {
+    test('calls repository.toggleFavourite with correct campsite ID', () {
+      const id = 'campId1';
+
+      toggleFavouriteUseCase(id);
+
+      verify(mockRepository.toggleFavourite(id)).called(1);
+    });
+  });
+}

--- a/test/features/favourites/presentation/providers/favourites_provider_test.dart
+++ b/test/features/favourites/presentation/providers/favourites_provider_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:wander_nest/features/favourites/presentation/providers/favourites_provider.dart';
+
+import '../../../../mocks/mocks.mocks.dart';
+
+void main() {
+  group('FavouritesProvider (StateNotifier)', () {
+    late MockFavouritesRepository mockRepository;
+    late ProviderContainer container;
+
+    setUp(() {
+      mockRepository = MockFavouritesRepository();
+
+      container = ProviderContainer(
+        overrides: [
+          favouritesRepositoryProvider.overrideWithValue(mockRepository),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('initial state is loaded from repository', () {
+      when(mockRepository.getFavouriteIds()).thenReturn({'campId1', 'campId2'});
+
+      final notifier = FavouritesNotifier(mockRepository);
+
+      expect(notifier.state, {'campId1', 'campId2'});
+    });
+
+    test('toggleFavourite adds and removes from favourites', () {
+      // Initial state
+      when(mockRepository.getFavouriteIds()).thenReturn({'campId1'});
+      final notifier = FavouritesNotifier(mockRepository);
+
+      // Simulate toggle (remove)
+      when(mockRepository.getFavouriteIds()).thenReturn({});
+      notifier.toggleFavourite('campId1');
+      expect(notifier.state, isEmpty);
+
+      // Simulate toggle (add again)
+      when(mockRepository.getFavouriteIds()).thenReturn({'campId1'});
+      notifier.toggleFavourite('campId1');
+      expect(notifier.state, {'campId1'});
+    });
+
+    test('isFavourite returns correct value', () {
+      when(mockRepository.getFavouriteIds()).thenReturn({'campId1', 'campId2'});
+      final notifier = FavouritesNotifier(mockRepository);
+
+      expect(notifier.isFavourite('campId1'), true);
+      expect(notifier.isFavourite('id3'), false);
+    });
+
+    test('toggleFavouriteUseCaseProvider calls repo.toggleFavourite()', () {
+      when(mockRepository.toggleFavourite('campId1')).thenAnswer((_) {});
+      final useCase = container.read(toggleFavouriteUseCaseProvider);
+
+      useCase('campId1');
+      verify(mockRepository.toggleFavourite('campId1')).called(1);
+    });
+
+    test('confirm favouritesProvider works via container', () {
+      when(mockRepository.getFavouriteIds()).thenReturn({'campId1'});
+      final state = container.read(favouritesProvider);
+
+      expect(state, {'campId1'});
+
+      // Toggle and update
+      when(mockRepository.getFavouriteIds()).thenReturn({'campId1', 'campId2'});
+      // Update notifier state
+      container.read(favouritesProvider.notifier).toggleFavourite('campId2');
+      expect(
+        container.read(favouritesProvider),
+        containsAll(['campId1', 'campId2']),
+      );
+    });
+  });
+}

--- a/test/mocks/mocks.dart
+++ b/test/mocks/mocks.dart
@@ -1,6 +1,11 @@
 import 'package:mockito/annotations.dart';
 import 'package:wander_nest/features/campsite/data/datasources/campsite_remote_data_source.dart';
 import 'package:wander_nest/features/campsite/domain/repositories/campsite_repository.dart';
+import 'package:wander_nest/features/favourites/domain/repositories/favourites_repository.dart';
 
-@GenerateMocks([CampsiteRemoteDataSource, CampsiteRepository])
+@GenerateMocks([
+  CampsiteRemoteDataSource,
+  CampsiteRepository,
+  FavouritesRepository,
+])
 void main() {}

--- a/test/mocks/mocks.mocks.dart
+++ b/test/mocks/mocks.mocks.dart
@@ -16,6 +16,8 @@ import 'package:wander_nest/features/campsite/domain/entities/campsite.dart'
     as _i8;
 import 'package:wander_nest/features/campsite/domain/repositories/campsite_repository.dart'
     as _i7;
+import 'package:wander_nest/features/favourites/domain/repositories/favourites_repository.dart'
+    as _i9;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -91,4 +93,36 @@ class MockCampsiteRepository extends _i1.Mock
             returnValue: _i5.Future<List<_i8.Campsite>>.value(<_i8.Campsite>[]),
           )
           as _i5.Future<List<_i8.Campsite>>);
+}
+
+/// A class which mocks [FavouritesRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockFavouritesRepository extends _i1.Mock
+    implements _i9.FavouritesRepository {
+  MockFavouritesRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  Set<String> getFavouriteIds() =>
+      (super.noSuchMethod(
+            Invocation.method(#getFavouriteIds, []),
+            returnValue: <String>{},
+          )
+          as Set<String>);
+
+  @override
+  bool isFavourite(String? campsiteId) =>
+      (super.noSuchMethod(
+            Invocation.method(#isFavourite, [campsiteId]),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
+  void toggleFavourite(String? campsiteId) => super.noSuchMethod(
+    Invocation.method(#toggleFavourite, [campsiteId]),
+    returnValueForMissingStub: null,
+  );
 }


### PR DESCRIPTION
**Favourites Feature**
- Users can mark/unmark campsites as favourites from the list or detail screens.
- Favourites are session-persistent and viewable on a separate page.
- Added unit test cases

**Reusable Views**
- Extracted AnimatedGridView<T> and AnimatedListView<T> as shared widgets.
- Used in both home and favourites pages for responsive layouts.